### PR TITLE
established connection

### DIFF
--- a/experimental/db-connection/main.go
+++ b/experimental/db-connection/main.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
+)
+
+func main() {
+	client, err := mongo.NewClient(options.Client().ApplyURI("mongodb://10.12.0.13:27017"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	err = client.Connect(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Disconnect(ctx)
+	err = client.Ping(ctx, readpref.Primary())
+	if err != nil {
+		log.Fatal(err)
+	}
+	databases, err := client.ListDatabaseNames(ctx, bson.M{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(databases)
+}

--- a/experimental/db-connection/pod.yaml
+++ b/experimental/db-connection/pod.yaml
@@ -1,0 +1,22 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: db-connection
+spec:
+  containers:
+    - name: db-connection
+      image: ko://github.com/googleinterns/knative-source-mongodb/experimental/db-connection


### PR DESCRIPTION
#5 
Was able to find a way to connect to the mongodb standalone:

Had to find the internal IP of the pod, making the URI be `mongodb://10.12.0.13:27017` (`mongodb://<internal IP>:<port>`)

Was able to successfully connect to the db and display the collections available including main-db which is the db I created to test.

![image](https://user-images.githubusercontent.com/20800119/86287738-b8609200-bbb6-11ea-99f2-23340a1718e9.png)
